### PR TITLE
Build SYNAPSE Git and GitHub infrastructure baseline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+* text=auto
+
+*.ps1 text eol=crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf
+*.sln text eol=crlf
+*.csproj text eol=crlf
+*.props text eol=crlf
+*.targets text eol=crlf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.7z binary
+*.dll binary
+*.exe binary
+*.so binary
+*.dylib binary

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @JKhyro
+/.github/ @JKhyro
+/infra/operator/ @JKhyro

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,39 @@
+name: Bug report
+description: Report a defect in the repository, shell contract, or operator baseline.
+title: "[Bug] "
+labels: []
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the defect plainly.
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Explain what is blocked or degraded.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Commands, UI steps, or repo context needed to reproduce.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Errors, logs, screenshots, or GitHub links.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Propose a bounded enhancement for SYNAPSE.
+title: "[Feature] "
+labels: []
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What outcome should this change unlock
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is in bounds for this request
+    validations:
+      required: true
+  - type: textarea
+    id: guardrails
+    attributes:
+      label: Guardrails
+      description: What should not happen as part of this change
+    validations:
+      required: true
+  - type: dropdown
+    id: boundary
+    attributes:
+      label: Primary boundary
+      options:
+        - Native C
+        - Avalonia host
+        - Native C interop
+        - GitHub/project surface
+        - Repository structure
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/git_github_infrastructure.yml
+++ b/.github/ISSUE_TEMPLATE/git_github_infrastructure.yml
@@ -1,0 +1,33 @@
+name: Git and GitHub infrastructure
+description: Request or track repo-level Git and GitHub operating changes.
+title: "[Infra] "
+labels: []
+body:
+  - type: textarea
+    id: surface
+    attributes:
+      label: Target surface
+      description: Repository files, workflow, project board, issue flow, or PR flow.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is missing, inconsistent, or blocked.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected improvement
+      description: What a correct repo or GitHub surface would look like.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation
+      description: How this should be verified locally or on GitHub.
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+- describe the concrete repository delta
+- link the issue this closes or advances
+
+## Validation
+
+- list commands run
+- list anything not verified
+
+## GitHub Surfaces
+
+- issue updated: yes or no
+- project item updated: yes or no
+- discussion updated: yes or no
+
+## Boundary Impact
+
+- Native C boundary changed: yes or no
+- Avalonia host boundary changed: yes or no
+- interop seam changed: yes or no
+
+## Notes
+
+- call out blockers such as missing auth scope or incomplete follow-on work

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Build outputs
+bin/
+obj/
+out/
+artifacts/
+build/
+
+# Native tool outputs
+*.o
+*.obj
+*.a
+*.lib
+*.so
+*.dylib
+*.dll
+*.exe
+*.pdb
+*.ilk
+*.exp
+
+# IDE and user state
+.vs/
+.vscode/
+.idea/
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Platform folders
+x64/
+x86/
+Debug/
+Release/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to SYNAPSE
+
+## Working Direction
+
+`SYNAPSE` is Native C first. Avalonia is the shell host. Native C interop is the seam. C# is only for host bootstrap, UI composition, and interop glue where necessary.
+
+Do not quietly move runtime ownership, launcher-core ownership, or section-boundary logic into managed code for convenience.
+
+## Git Conventions
+
+- open or link the relevant GitHub issue before starting implementation
+- use branch names prefixed with `codex/`
+- keep one coherent branch per bounded task
+- write commit messages that describe the actual delta, not the intent alone
+- update the linked issue, PR, and project card when execution state materially changes
+
+## Pull Requests
+
+Every pull request should state:
+
+- the issue it closes or advances
+- the exact repository or GitHub surfaces changed
+- the validation that was run
+- whether the Native C versus Avalonia boundary changed
+
+Use `.github/pull_request_template.md` as the default structure.
+
+## Repository Operating Surfaces
+
+- `.github/ISSUE_TEMPLATE/` for structured issue intake
+- `.github/pull_request_template.md` for PR writeback discipline
+- `.github/CODEOWNERS` for review routing
+- `infra/operator/GIT_GITHUB_INFRASTRUCTURE.md` for repo-level operating rules
+- `infra/operator/GITHUB_THREAD_BOOTSTRAP.md` for a quick thread-start bootstrap
+- `infra/operator/github_surface_catalog.json` for machine-readable metadata
+- `infra/operator/verify_git_github_infrastructure.ps1` for local verification
+
+## Local Validation
+
+Run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\infra\operator\verify_git_github_infrastructure.ps1 -RepoRoot .
+```
+
+If GitHub auth is intentionally unavailable, use:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\infra\operator\verify_git_github_infrastructure.ps1 -RepoRoot . -SkipGh
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # SYNAPSE
+
 Suite shell for the packaged SYMBIOSIS control interface spanning CORTEX, VECTOR, FORGE, ANVIL, and NEXUS.
+
+## Direction
+
+- Native C owns core program logic, runtime boundaries, process control, and section entrypoints.
+- Avalonia acts as the desktop shell, window composition layer, and managed host surface.
+- Native C interop is the default seam between the shell and the core program surfaces.
+- C# is limited to thin host bootstrap, UI composition, and interop glue where managed code is materially cheaper than reimplementing the same seam in Native C.
+
+## Repository Baseline
+
+This repository carries the Git and GitHub operating baseline needed to move `SYNAPSE` work through one coherent path:
+
+- issue templates and PR template under `.github/`
+- Git conventions and contribution rules in `CONTRIBUTING.md`
+- operator documentation and repository verification under `infra/operator/`
+- a machine-readable GitHub surface catalog for automation and validation
+
+## Active Surfaces
+
+- Repository: `JKhyro/SYNAPSE`
+- Project: `JKhyro` project `#18` (`SYNAPSE`)
+- Infrastructure lane: `JKhyro/SYNAPSE#13`
+- Native host lane: `JKhyro/SYNAPSE#10`
+- Package topology lane: `JKhyro/SYNAPSE#12`
+
+## Validation
+
+Run the local infrastructure check from the repository root:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\infra\operator\verify_git_github_infrastructure.ps1 -RepoRoot .
+```
+
+Use `-SkipGh` when you only need repository-file verification and do not want to query live GitHub.

--- a/infra/operator/GITHUB_THREAD_BOOTSTRAP.md
+++ b/infra/operator/GITHUB_THREAD_BOOTSTRAP.md
@@ -1,0 +1,25 @@
+# SYNAPSE GitHub Thread Bootstrap
+
+Use this repository-level bootstrap when a thread needs fast `SYNAPSE` Git and GitHub context.
+
+## Repo and Project
+
+- repository: `JKhyro/SYNAPSE`
+- project: `JKhyro` project `#18`
+- active infrastructure issue: `JKhyro/SYNAPSE#13`
+
+## Quick Commands
+
+```powershell
+gh repo view JKhyro/SYNAPSE
+gh issue list --repo JKhyro/SYNAPSE --limit 20
+gh project item-list 18 --owner JKhyro --limit 200
+git status --short --branch
+powershell -ExecutionPolicy Bypass -File .\infra\operator\github_context_probe.ps1 -RepoRoot .
+```
+
+## Local Verification
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\infra\operator\verify_git_github_infrastructure.ps1 -RepoRoot .
+```

--- a/infra/operator/GIT_GITHUB_INFRASTRUCTURE.md
+++ b/infra/operator/GIT_GITHUB_INFRASTRUCTURE.md
@@ -1,0 +1,53 @@
+# SYNAPSE Git and GitHub Infrastructure
+
+## Purpose
+
+This document defines the baseline repository surfaces that keep `SYNAPSE` execution coherent across local Git, GitHub issues, pull requests, and the `SYNAPSE` project board.
+
+## Canonical Targets
+
+- repository: `JKhyro/SYNAPSE`
+- project: `JKhyro` project `#18` (`SYNAPSE`)
+- infrastructure issue: `JKhyro/SYNAPSE#13`
+- linked execution lanes:
+  - `JKhyro/SYNAPSE#8`
+  - `JKhyro/SYNAPSE#10`
+  - `JKhyro/SYNAPSE#12`
+
+## Required Repository Surfaces
+
+- `.gitignore`
+- `.gitattributes`
+- `.github/CODEOWNERS`
+- `.github/ISSUE_TEMPLATE/config.yml`
+- `.github/ISSUE_TEMPLATE/bug_report.yml`
+- `.github/ISSUE_TEMPLATE/feature_request.yml`
+- `.github/ISSUE_TEMPLATE/git_github_infrastructure.yml`
+- `.github/pull_request_template.md`
+- `.github/workflows/git-github-infrastructure.yml`
+- `CONTRIBUTING.md`
+- `infra/operator/GITHUB_THREAD_BOOTSTRAP.md`
+- `infra/operator/github_context_probe.ps1`
+- `infra/operator/github_surface_catalog.json`
+- `infra/operator/verify_git_github_infrastructure.ps1`
+
+## Working Rules
+
+- open or link a GitHub issue before implementation starts
+- use `codex/` branch names
+- keep GitHub issue, PR, and project-card state synchronized when execution meaningfully changes
+- preserve the Native C first, Avalonia second, interop seam third direction in repo metadata and docs
+
+## Verification
+
+Run from the repository root:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\infra\operator\verify_git_github_infrastructure.ps1 -RepoRoot .
+```
+
+Use `-SkipGh` when live GitHub checks are intentionally unavailable.
+
+## Workflow Publishing Note
+
+Workflow files require GitHub credentials that are permitted to create or update `.github/workflows/*`. If that scope is unavailable, keep the workflow file in the local branch, push the remaining baseline through a GitHub-safe branch, and record the blocker on the active issue and PR.

--- a/infra/operator/github_context_probe.ps1
+++ b/infra/operator/github_context_probe.ps1
@@ -1,0 +1,24 @@
+param(
+    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+)
+
+$ErrorActionPreference = "Stop"
+
+$catalogPath = Join-Path $RepoRoot "infra\operator\github_surface_catalog.json"
+$catalog = Get-Content $catalogPath -Raw | ConvertFrom-Json
+
+$gitStatus = git -C $RepoRoot status --short --branch
+$remote = git -C $RepoRoot remote get-url origin
+
+$issues = gh issue list --repo $catalog.repository.slug --limit 10 --json number,title,state,updatedAt | ConvertFrom-Json
+
+[pscustomobject]@{
+    repo_root = $RepoRoot
+    repository = $catalog.repository.slug
+    project = $catalog.project.title
+    infrastructure_issue = $catalog.issues.infrastructure
+    branch_prefix = $catalog.repository.branch_prefix
+    remote = $remote
+    git_status = $gitStatus
+    recent_issues = $issues
+} | ConvertTo-Json -Depth 6

--- a/infra/operator/github_surface_catalog.json
+++ b/infra/operator/github_surface_catalog.json
@@ -1,0 +1,38 @@
+{
+  "repository": {
+    "owner": "JKhyro",
+    "name": "SYNAPSE",
+    "slug": "JKhyro/SYNAPSE",
+    "default_branch": "main",
+    "branch_prefix": "codex/"
+  },
+  "project": {
+    "owner": "JKhyro",
+    "number": 18,
+    "title": "SYNAPSE"
+  },
+  "issues": {
+    "infrastructure": 13,
+    "scaffold": 8,
+    "host": 10,
+    "topology": 12
+  },
+  "required_files": [
+    ".gitignore",
+    ".gitattributes",
+    ".github/CODEOWNERS",
+    ".github/ISSUE_TEMPLATE/config.yml",
+    ".github/ISSUE_TEMPLATE/bug_report.yml",
+    ".github/ISSUE_TEMPLATE/feature_request.yml",
+    ".github/ISSUE_TEMPLATE/git_github_infrastructure.yml",
+    ".github/pull_request_template.md",
+    ".github/workflows/git-github-infrastructure.yml",
+    "CONTRIBUTING.md",
+    "README.md",
+    "infra/operator/GIT_GITHUB_INFRASTRUCTURE.md",
+    "infra/operator/GITHUB_THREAD_BOOTSTRAP.md",
+    "infra/operator/github_context_probe.ps1",
+    "infra/operator/github_surface_catalog.json",
+    "infra/operator/verify_git_github_infrastructure.ps1"
+  ]
+}

--- a/infra/operator/verify_git_github_infrastructure.ps1
+++ b/infra/operator/verify_git_github_infrastructure.ps1
@@ -1,0 +1,95 @@
+param(
+    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path,
+    [switch]$SkipGh
+)
+
+$ErrorActionPreference = "Stop"
+
+function Add-Result {
+    param(
+        [System.Collections.Generic.List[object]]$Results,
+        [string]$Name,
+        [bool]$Ok,
+        [string]$Detail
+    )
+
+    $Results.Add([pscustomobject]@{
+        name = $Name
+        ok = $Ok
+        detail = $Detail
+    })
+}
+
+$results = [System.Collections.Generic.List[object]]::new()
+
+if (-not (Test-Path $RepoRoot)) {
+    throw "Repository root not found: $RepoRoot"
+}
+
+Add-Result -Results $results -Name "repo-root" -Ok $true -Detail $RepoRoot
+
+$catalogPath = Join-Path $RepoRoot "infra\operator\github_surface_catalog.json"
+if (-not (Test-Path $catalogPath)) {
+    Add-Result -Results $results -Name "catalog-load" -Ok $false -Detail $catalogPath
+    $results | Format-Table -AutoSize
+    throw "Git and GitHub infrastructure verification failed."
+}
+
+$catalog = Get-Content $catalogPath -Raw | ConvertFrom-Json
+Add-Result -Results $results -Name "catalog-load" -Ok $true -Detail $catalogPath
+
+foreach ($relativePath in $catalog.required_files) {
+    $fullPath = Join-Path $RepoRoot $relativePath
+    Add-Result -Results $results -Name ("required-file:" + $relativePath) -Ok (Test-Path $fullPath) -Detail $fullPath
+}
+
+$origin = ""
+try {
+    $origin = git -C $RepoRoot remote get-url origin
+    Add-Result -Results $results -Name "git-origin" -Ok ($origin -eq "https://github.com/JKhyro/SYNAPSE.git") -Detail $origin
+}
+catch {
+    Add-Result -Results $results -Name "git-origin" -Ok $false -Detail $_.Exception.Message
+}
+
+try {
+    $branch = (git -C $RepoRoot rev-parse --abbrev-ref HEAD).Trim()
+    $branchOk = ($branch -eq $catalog.repository.default_branch) -or $branch.StartsWith($catalog.repository.branch_prefix)
+    Add-Result -Results $results -Name "branch-policy" -Ok $branchOk -Detail ("branch=" + $branch + "; prefix=" + $catalog.repository.branch_prefix)
+}
+catch {
+    Add-Result -Results $results -Name "branch-policy" -Ok $false -Detail $_.Exception.Message
+}
+
+if ($catalog.project.number -eq 18) {
+    Add-Result -Results $results -Name "catalog-project-number" -Ok $true -Detail "18"
+}
+else {
+    Add-Result -Results $results -Name "catalog-project-number" -Ok $false -Detail ("project=" + $catalog.project.number)
+}
+
+if (-not $SkipGh) {
+    try {
+        $repoJson = gh repo view $catalog.repository.slug --json nameWithOwner,defaultBranchRef,url | ConvertFrom-Json
+        $repoOk = ($repoJson.nameWithOwner -eq $catalog.repository.slug) -and ($repoJson.defaultBranchRef.name -eq $catalog.repository.default_branch)
+        Add-Result -Results $results -Name "gh-repo-view" -Ok $repoOk -Detail ($repoJson.url)
+    }
+    catch {
+        Add-Result -Results $results -Name "gh-repo-view" -Ok $false -Detail $_.Exception.Message
+    }
+
+    try {
+        $issueJson = gh issue view $catalog.issues.infrastructure --repo $catalog.repository.slug --json number,title,state,url | ConvertFrom-Json
+        $issueOk = ($issueJson.number -eq $catalog.issues.infrastructure) -and ($issueJson.state -eq "OPEN")
+        Add-Result -Results $results -Name "gh-infrastructure-issue" -Ok $issueOk -Detail ($issueJson.url)
+    }
+    catch {
+        Add-Result -Results $results -Name "gh-infrastructure-issue" -Ok $false -Detail $_.Exception.Message
+    }
+}
+
+$results | Format-Table -AutoSize
+
+if (($results | Where-Object { -not $_.ok }).Count -gt 0) {
+    throw "Git and GitHub infrastructure verification failed."
+}


### PR DESCRIPTION
## Summary
- build the repo-level Git and GitHub operating baseline for SYNAPSE
- add issue templates, PR template, CODEOWNERS, and contribution guidance
- add operator docs, a GitHub surface catalog, and a repository verification script
- update the README to make the Native C first, Avalonia host, C interop, and C#-only-where-necessary direction explicit

## Validation
- `powershell -ExecutionPolicy Bypass -File .\infra\operator\verify_git_github_infrastructure.ps1 -RepoRoot C:\Users\Allan\OneDrive\Documents\SYNAPSE`
- `powershell -ExecutionPolicy Bypass -File .\infra\operator\github_context_probe.ps1 -RepoRoot C:\Users\Allan\OneDrive\Documents\SYNAPSE`

## Blocker
- the full local baseline also includes `.github/workflows/git-github-infrastructure.yml`
- pushing workflow files is currently blocked by the active HTTPS OAuth token missing the `workflow` scope
- the full local branch is preserved at `codex/synapse-git-github-infrastructure` and can be pushed once the credential scope is corrected

Related to #13
